### PR TITLE
Fix save suppliers with an admin role

### DIFF
--- a/app/controllers/solidus_marketplace/admin/products_controller_decorator.rb
+++ b/app/controllers/solidus_marketplace/admin/products_controller_decorator.rb
@@ -26,6 +26,7 @@ module SolidusMarketplace
           elsif removing_suppliers?
             supplier_ids = current_supplier_ids - new_supplier_ids
             @product.remove_suppliers!(supplier_ids)
+            @product.add_suppliers!(new_supplier_ids) if new_supplier_ids
           elsif same_number_of_suppliers? && different_suppliers?
             @product.remove_suppliers!(current_suppliers)
             @product.add_suppliers!(new_suppliers)
@@ -78,9 +79,15 @@ module SolidusMarketplace
 
         # Newly added products by a Supplier are associated with it.
         def add_product_to_supplier
-          if try_spree_current_user && try_spree_current_user.supplier?
+          if try_spree_current_user&.supplier?
            @product.add_supplier!(try_spree_current_user.supplier_id)
+          elsif user_admin?
+            @product.add_suppliers!(new_supplier_ids)
           end
+        end
+
+        def user_admin?
+          try_spree_current_user.admin?
         end
       end
     end


### PR DESCRIPTION
Quick Info
---
1. When a user with an admin role creates a new product and they assign a supplier, the supplier is not being saved and the user must edit the created product to assign the supplier again.
2. Also when an admin user updates a product in this scenario:
  * The user deletes the supplier associated
  * The user adds new suppliers (more than the number of suppliers that had before).
The new suppliers are not being saved.

Migrations? 👎:

What does this change?
----
- Fix when a user with an admin role saves a supplier when creating a new product. Also when a user removes a supplier and assigns new ones.

Why are you changing that?
----
- Because the user needs to re-assign the suppliers again in order to save them, otherwise the product is saved without a supplier associated.
- This also happens when the user deletes a supplier and they want to assign new ones, firstly, they need to delete the supplier, then save the product, then edit again the product and assign the new associated suppliers.

How did you accomplish this change?
----
1. I added a validation for those users with an admin role in order to save the supplier when creating a product.
2. I called the **add_suppliers** method when a user deletes a supplier and adds new ones.

