### PR TITLE
move module attribute outside singleton class

### DIFF
--- a/lib/solidus_marketplace/permitted_attributes.rb
+++ b/lib/solidus_marketplace/permitted_attributes.rb
@@ -21,8 +21,8 @@ module SolidusMarketplace
         :slug,
         :paypal_email
       ]
-
-      mattr_reader(:supplier_attributes)
     end
+
+    mattr_reader(:supplier_attributes)
   end
 end


### PR DESCRIPTION
I got an error when running tests using rails 6.1.0
```
TypeError:
  module attributes should be defined directly on class, not singleton
```

moving the module attribute outside singleton class solve the problem