### PR TITLE
Fix a typo in the setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ bundle exec rails g solidus_marketplace:install
 (Optional) If you want to be able to see the reports, please add this line to your `Gemfile`:
 
 ```ruby
-gem 'solidus_reports', github: 'solidus-contrib/solidus_reports'
+gem 'solidus_reports', github: 'solidusio-contrib/solidus_reports'
 ```
 
 (Optional) If you want to use Stripe or other payment providers, please add this line to your `Gemfile`:


### PR DESCRIPTION
The `solidus-contrib` organisation seems to have been renamed `solidusio-contrib`, so let's update the README to reflect that change.